### PR TITLE
Stop apostrophes being mistaken for opening single quote marks

### DIFF
--- a/grammars/twee2.cson
+++ b/grammars/twee2.cson
@@ -141,7 +141,7 @@
           },
           # Single Quotes
           {
-            "match": "('[^']*')",
+            "match": "(?<!\\w)('[^']*')(?!\\w)",
             "name": "string.quoted.single.twee2"
           },
           # Double Quotes
@@ -297,7 +297,7 @@
           },
           # Single Quotes
           {
-            "match": "('[^']*')",
+            "match": "(?<!\\w)('[^']*')(?!\\w)",
             "name": "string.quoted.single.twee2"
           },
           # Double Quotes

--- a/grammars/twee2.cson
+++ b/grammars/twee2.cson
@@ -141,7 +141,7 @@
           },
           # Single Quotes
           {
-            "match": "(?<!\\w)('[^']*')(?!\\w)",
+            "match": "(?<!\\w)('[^']*')",
             "name": "string.quoted.single.twee2"
           },
           # Double Quotes
@@ -297,7 +297,7 @@
           },
           # Single Quotes
           {
-            "match": "(?<!\\w)('[^']*')(?!\\w)",
+            "match": "(?<!\\w)('[^']*')",
             "name": "string.quoted.single.twee2"
           },
           # Double Quotes


### PR DESCRIPTION
Harlowe uses constructs like `$array's 1st` and `$datamap's key`, where single quotes are used to denote possession rather than delimit a string.

This PR adds a lookbehind test to ensure that quote marks in the middle of words (or more precisely, immediately preceded by a word character) are ignored for the purposes of delimiting the start of strings.